### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,9 @@ If you believe you have found a security vulnerability in any Target-owned repos
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please send an email to [security@target.com](mailto:security@target.com). 
+Instead, please report them to the Target Cyber Security team at https://security.target.com/vdp.
+
+If you prefer to submit without logging in, send an email to [security@target.com](mailto:security@target.com).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found published under Security/Advisories for each repository, if applicable.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,3 @@ This information will help us triage your report more quickly.
 ## Preferred Languages
 
 We prefer all communications to be in English.
-
-## Policy
-
-Target follows the principle of [Coordinated Vulnerability Disclosure]().

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ If you believe you have found a security vulnerability in any Target-owned repos
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Target Cyber Security team at https://security.target.com/vdp.
+Instead, please send an email to [security@target.com](mailto:security@target.com).
 
-If you prefer to submit without logging in, send an email to [security@target.com](mailto:security@target.com).
+Learn more about Target's [Security Vulnerability Reporting Policy](https://security.target.com/vdp)
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found published under Security/Advisories for each repository, if applicable.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security
+
+Target takes the security of our software products and services seriously, which includes all source code repositories managed through [our GitHub organizations](https://opensource.target.com).
+
+If you believe you have found a security vulnerability in any Target-owned repository that meets Target's definition of a security vulnerability, please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Target Cyber Security team at _____.
+
+If you prefer to submit without logging in, send an email to _____. If possible, encrypt your message with our PGP key; please download it from _____.
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at _____.
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+-	Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+-	Full paths of source file(s) related to the manifestation of the issue
+-	The location of the affected source code (tag/branch/commit or direct URL)
+-	Any special configuration required to reproduce the issue
+-	Step-by-step instructions to reproduce the issue
+-	Proof-of-concept or exploit code (if possible)
+-	Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Target follows the principle of [Coordinated Vulnerability Disclosure]().

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,11 +8,9 @@ If you believe you have found a security vulnerability in any Target-owned repos
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Target Cyber Security team at _____.
+Intead, please send an email to security@target.com. 
 
-If you prefer to submit without logging in, send an email to _____. If possible, encrypt your message with our PGP key; please download it from _____.
-
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at _____.
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found published under Security/Advisories for each repository, if applicable.
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ If you believe you have found a security vulnerability in any Target-owned repos
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Intead, please send an email to security@target.com. 
+Instead, please send an email to [security@target.com](mailto:security@target.com). 
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found published under Security/Advisories for each repository, if applicable.
 


### PR DESCRIPTION
This was given to me by Ryan

## Review

I've shared this now with the following stakeholders for review:

- open source office staff
- security staff

## Effect

Merging this policy will apply the security policy documentation across all repositories within the organization (unless they have added their own):

right side nav on repos

<img width="324" alt="image" src="https://user-images.githubusercontent.com/298435/202298268-c7d8d584-30ea-4558-972c-6b388055b5fd.png">

new issue ui

![image](https://user-images.githubusercontent.com/298435/202298358-c98b96cd-c806-4743-863e-768eaaca9b47.png)

security policy ui

![image](https://user-images.githubusercontent.com/298435/202298413-53fe3d63-0aa3-4c00-8e36-62666597ed51.png)
